### PR TITLE
Xbox WDP Tool Enhancements

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -19,3 +19,15 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+HBO
+
+Copyright (c) 2013 Home Box Office, Inc. as an unpublished
+work. Neither this material nor any portion hereof may be copied or
+distributed without the express written consent of Home Box Office, Inc.
+
+This material also contains proprietary and confidential information
+of Home Box Office, Inc. and its suppliers, and may not be used by or
+disclosed to any person, in whole or in part, without the prior written
+consent of Home Box Office, Inc.

--- a/Samples/XboxWdpDriver/Operations/AppOperation.cs
+++ b/Samples/XboxWdpDriver/Operations/AppOperation.cs
@@ -5,9 +5,11 @@
 //----------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Tools.WindowsDevicePortal;
 using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
+
 
 namespace XboxWdpDriver
 {
@@ -22,9 +24,11 @@ namespace XboxWdpDriver
         private const string AppUsageMessage = "Usage:\n" +
             "  /subop:list\n" +
             "        Lists all installed packages on the console.\n" +
-    // Suspend and resume are currently not supported. The endpoints are not very
-    // reliable yet on Xbox One and are completely unavailable on other platforms.
-    // We'll revisit these two operations in the future.
+            "  /subop:listRunningApps\n" +
+            "        Lists all running app packages on the console.\n" +
+            // Suspend and resume are currently not supported. The endpoints are not very
+            // reliable yet on Xbox One and are completely unavailable on other platforms.
+            // We'll revisit these two operations in the future.
             //"  /subop:suspend /pfn:<packageFullName>\n" +
             //"        Suspends the requested application.\n" +
             //"  /subop:resume /pfn:<packageFullName>\n" +
@@ -69,6 +73,24 @@ namespace XboxWdpDriver
 
                     packagesTask.Wait();
                     Console.WriteLine(packagesTask.Result);
+                }
+                else if (operationType.Equals("listrunningapps"))
+                {
+                    Task<List<string>> packagesTask = portal.GetRunningAppsAsync();
+
+                    packagesTask.Wait();
+                    if (packagesTask.Result.Count > 0)
+                    {
+                        Console.WriteLine("Running Apps:");
+                        for (int i = 0; i < packagesTask.Result.Count; i++)
+                        {
+                            Console.WriteLine(packagesTask.Result[i]);
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("No Apps are running");
+                    }
                 }
                 else
                 {

--- a/Samples/XboxWdpDriver/Operations/AppOperation.cs
+++ b/Samples/XboxWdpDriver/Operations/AppOperation.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.Tools.WindowsDevicePortal;
 using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
 
-
 namespace XboxWdpDriver
 {
     /// <summary>
@@ -79,7 +78,7 @@ namespace XboxWdpDriver
                 }
                 else if (operationType.Equals("listrunningapps") || operationType.Equals("listsuspendedapps"))
                 {
-                    string appState = (operationType.Equals("listrunningapps") ? "Running" : "Suspended");
+                    string appState = operationType.Equals("listrunningapps") ? "Running" : "Suspended";
                     Task<List<string>> packagesTask = portal.GetAppListAsync(appState);
 
                     packagesTask.Wait();

--- a/Samples/XboxWdpDriver/Operations/AppOperation.cs
+++ b/Samples/XboxWdpDriver/Operations/AppOperation.cs
@@ -2,6 +2,9 @@
 // <copyright file="AppOperation.cs" company="Microsoft Corporation">
 //     Licensed under the MIT License. See LICENSE.TXT in the project root license information.
 // </copyright>
+// <copyright file="AppOperation.cs" company="HBO">
+//     Modified to support listing running and suspended apps. See LICENSE.TXT in the project root for license information.
+// </copyright>
 //----------------------------------------------------------------------------------------------
 
 using System;
@@ -85,9 +88,9 @@ namespace XboxWdpDriver
                     if (packagesTask.Result.Count > 0)
                     {
                         Console.WriteLine(appState + " Apps:");
-                        for (int i = 0; i < packagesTask.Result.Count; i++)
+                        foreach(var package in packagesTask.Result)
                         {
-                            Console.WriteLine(packagesTask.Result[i]);
+                            Console.WriteLine(package);
                         }
                     }
                     else

--- a/Samples/XboxWdpDriver/Operations/AppOperation.cs
+++ b/Samples/XboxWdpDriver/Operations/AppOperation.cs
@@ -88,7 +88,7 @@ namespace XboxWdpDriver
                     if (packagesTask.Result.Count > 0)
                     {
                         Console.WriteLine(appState + " Apps:");
-                        foreach(var package in packagesTask.Result)
+                        foreach (var package in packagesTask.Result)
                         {
                             Console.WriteLine(package);
                         }

--- a/Samples/XboxWdpDriver/Operations/AppOperation.cs
+++ b/Samples/XboxWdpDriver/Operations/AppOperation.cs
@@ -14,7 +14,8 @@ using static Microsoft.Tools.WindowsDevicePortal.DevicePortal;
 namespace XboxWdpDriver
 {
     /// <summary>
-    /// Helper for App related operations (List, Suspend, Resume, Launch, Terminate, Uninstall)
+    /// Helper for App related operations (List, ListRunningApps, ListSuspendedApps,
+    /// Suspend, Resume, Launch, Terminate, Uninstall)
     /// </summary>
     public class AppOperation
     {
@@ -25,6 +26,8 @@ namespace XboxWdpDriver
             "  /subop:list\n" +
             "        Lists all installed packages on the console.\n" +
             "  /subop:listRunningApps\n" +
+            "        Lists all running app packages on the console.\n" +
+            "  /subop:listSuspendedApps\n" +
             "        Lists all running app packages on the console.\n" +
             // Suspend and resume are currently not supported. The endpoints are not very
             // reliable yet on Xbox One and are completely unavailable on other platforms.
@@ -89,7 +92,25 @@ namespace XboxWdpDriver
                     }
                     else
                     {
-                        Console.WriteLine("No Apps are running");
+                        Console.WriteLine("No Apps are currently Running");
+                    }
+                }
+                else if (operationType.Equals("listsuspendedapps"))
+                {
+                    Task<List<string>> packagesTask = portal.GetSuspendedAppsAsync();
+
+                    packagesTask.Wait();
+                    if (packagesTask.Result.Count > 0)
+                    {
+                        Console.WriteLine("Suspended Apps:");
+                        for (int i = 0; i < packagesTask.Result.Count; i++)
+                        {
+                            Console.WriteLine(packagesTask.Result[i]);
+                        }
+                    }
+                    else
+                    {
+                        Console.WriteLine("No Apps are currently Suspended");
                     }
                 }
                 else

--- a/Samples/XboxWdpDriver/Operations/AppOperation.cs
+++ b/Samples/XboxWdpDriver/Operations/AppOperation.cs
@@ -77,14 +77,15 @@ namespace XboxWdpDriver
                     packagesTask.Wait();
                     Console.WriteLine(packagesTask.Result);
                 }
-                else if (operationType.Equals("listrunningapps"))
+                else if (operationType.Equals("listrunningapps") || operationType.Equals("listsuspendedapps"))
                 {
-                    Task<List<string>> packagesTask = portal.GetRunningAppsAsync();
+                    string appState = (operationType.Equals("listrunningapps") ? "Running" : "Suspended");
+                    Task<List<string>> packagesTask = portal.GetAppListAsync(appState);
 
                     packagesTask.Wait();
                     if (packagesTask.Result.Count > 0)
                     {
-                        Console.WriteLine("Running Apps:");
+                        Console.WriteLine(appState + " Apps:");
                         for (int i = 0; i < packagesTask.Result.Count; i++)
                         {
                             Console.WriteLine(packagesTask.Result[i]);
@@ -92,25 +93,7 @@ namespace XboxWdpDriver
                     }
                     else
                     {
-                        Console.WriteLine("No Apps are currently Running");
-                    }
-                }
-                else if (operationType.Equals("listsuspendedapps"))
-                {
-                    Task<List<string>> packagesTask = portal.GetSuspendedAppsAsync();
-
-                    packagesTask.Wait();
-                    if (packagesTask.Result.Count > 0)
-                    {
-                        Console.WriteLine("Suspended Apps:");
-                        for (int i = 0; i < packagesTask.Result.Count; i++)
-                        {
-                            Console.WriteLine(packagesTask.Result[i]);
-                        }
-                    }
-                    else
-                    {
-                        Console.WriteLine("No Apps are currently Suspended");
+                        Console.WriteLine("No Apps are currently " + appState);
                     }
                 }
                 else

--- a/Samples/XboxWdpDriver/Program.cs
+++ b/Samples/XboxWdpDriver/Program.cs
@@ -2,6 +2,9 @@
 // <copyright file="Program.cs" company="Microsoft Corporation">
 //     Licensed under the MIT License. See LICENSE.TXT in the project root license information.
 // </copyright>
+// <copyright file="Program.cs" company="HBO">
+//     Modified docs to include listing running and suspended apps. See LICENSE.TXT in the project root for license information.
+// </copyright>
 //----------------------------------------------------------------------------------------------
 
 using System;

--- a/Samples/XboxWdpDriver/Program.cs
+++ b/Samples/XboxWdpDriver/Program.cs
@@ -65,8 +65,8 @@ namespace XboxWdpDriver
             None,
 
             /// <summary>
-            /// Perform an App operation (List, ListRunningApps, Suspend, Resume, Launch,
-            /// Terminate, Uninstall)
+            /// Perform an App operation (List, ListRunningApps, ListSuspendedApps, Suspend, Resume,
+            /// Launch, Terminate, Uninstall)
             /// </summary>
             AppOperation,
 

--- a/Samples/XboxWdpDriver/Program.cs
+++ b/Samples/XboxWdpDriver/Program.cs
@@ -65,8 +65,8 @@ namespace XboxWdpDriver
             None,
 
             /// <summary>
-            /// Perform an App operation (List, Suspend, Resume, Launch, Terminate,
-            /// Uninstall)
+            /// Perform an App operation (List, ListRunningApps, Suspend, Resume, Launch,
+            /// Terminate, Uninstall)
             /// </summary>
             AppOperation,
 

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
@@ -2,6 +2,9 @@
 // <copyright file="TaskManager.cs" company="Microsoft Corporation">
 //     Licensed under the MIT License. See LICENSE.TXT in the project root license information.
 // </copyright>
+// <copyright file="TaskManager.cs" company="HBO">
+//     Support listing running and suspended apps on Xbox. See LICENSE.TXT in the project root for license information.
+// </copyright>
 //----------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
@@ -54,48 +54,29 @@ namespace Microsoft.Tools.WindowsDevicePortal
         }
 
         /// <summary>
-        /// Gets the current running apps on the console based on app processes
+        /// Gets the current list of apps on the console in the state specified
         /// </summary>
-        /// <returns>List of Package Full Names of running apps</returns>
-        public async Task<List<string>> GetRunningAppsAsync()
+        /// <param name="appState">State of apps to be returned as a string - "running" or "suspended"</param>
+        /// <returns>List of Package Full Names of running or suspended apps</returns>
+        public async Task<List<string>> GetAppListAsync(string appState)
         {
             RunningProcesses appProcesses = await this.GetRunningProcessesAsync();
-            List<string> runningApps = new List<string>();
+            List<string> apps = new List<string>();
 
+            var shouldBeRunning = (appState.ToLower().Equals("running")) ? true : false;
             foreach (DeviceProcessInfo process in appProcesses.Processes)
             {
-                // There can be multiple processes per app, so only add an app package name if it doesn't already
-                // exist in the list and it is actually running - processes listed can be in the suspended state
-                if (process.PackageFullName != null && process.IsRunning && !runningApps.Contains(process.PackageFullName))
+                // There can be multiple processes per app, so only add an app package name if it
+                // doesn't already exist in the list and matches the state requested
+                if (process.PackageFullName != null && !apps.Contains(process.PackageFullName) && process.IsRunning == shouldBeRunning)
                 {
-                    runningApps.Add(process.PackageFullName);
+                    apps.Add(process.PackageFullName);
                 }
             }
 
-            return runningApps;
+            return apps;
         }
 
-        /// <summary>
-        /// Gets the current suspended apps on the console based on app processes
-        /// </summary>
-        /// <returns>List of Package Full Names of suspended apps</returns>
-        public async Task<List<string>> GetSuspendedAppsAsync()
-        {
-            RunningProcesses appProcesses = await this.GetRunningProcessesAsync();
-            List<string> suspendedApps = new List<string>();
-
-            foreach (DeviceProcessInfo process in appProcesses.Processes)
-            {
-                // There can be multiple processes per app, so only add an app package name if it doesn't already
-                // exist in the list and it is in a suspended state (not running)
-                if (process.PackageFullName != null && !process.IsRunning && !suspendedApps.Contains(process.PackageFullName))
-                {
-                    suspendedApps.Add(process.PackageFullName);
-                }
-            }
-
-            return suspendedApps;
-        }
 
         /// <summary>
         /// Stops the specified application from running.

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Tools.WindowsDevicePortal
             RunningProcesses appProcesses = await this.GetRunningProcessesAsync();
             List<string> apps = new List<string>();
 
-            var shouldBeRunning = (appState.ToLower().Equals("running")) ? true : false;
+            var shouldBeRunning = appState.ToLower().Equals("running") ? true : false;
             foreach (DeviceProcessInfo process in appProcesses.Processes)
             {
                 // There can be multiple processes per app, so only add an app package name if it

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
@@ -53,22 +53,48 @@ namespace Microsoft.Tools.WindowsDevicePortal
             return processId;
         }
 
+        /// <summary>
+        /// Gets the current running apps on the console based on app processes
+        /// </summary>
+        /// <returns>List of Package Full Names of running apps</returns>
         public async Task<List<string>> GetRunningAppsAsync()
         {
-            RunningProcesses runningApps = await this.GetRunningProcessesAsync();
-            List<string> runningProcessNames = new List<string>();
+            RunningProcesses appProcesses = await this.GetRunningProcessesAsync();
+            List<string> runningApps = new List<string>();
 
-            foreach (DeviceProcessInfo process in runningApps.Processes)
+            foreach (DeviceProcessInfo process in appProcesses.Processes)
             {
-                // There can be multiple processes per app, so only add an app package name
-                // if it doesn't already exist in the list
-                if (process.PackageFullName != null && !runningProcessNames.Contains(process.PackageFullName))
+                // There can be multiple processes per app, so only add an app package name if it doesn't already
+                // exist in the list and it is actually running - processes listed can be in the suspended state
+                if (process.PackageFullName != null && process.IsRunning && !runningApps.Contains(process.PackageFullName))
                 {
-                    runningProcessNames.Add(process.PackageFullName);
+                    runningApps.Add(process.PackageFullName);
                 }
             }
 
-            return runningProcessNames;
+            return runningApps;
+        }
+
+        /// <summary>
+        /// Gets the current suspended apps on the console based on app processes
+        /// </summary>
+        /// <returns>List of Package Full Names of suspended apps</returns>
+        public async Task<List<string>> GetSuspendedAppsAsync()
+        {
+            RunningProcesses appProcesses = await this.GetRunningProcessesAsync();
+            List<string> suspendedApps = new List<string>();
+
+            foreach (DeviceProcessInfo process in appProcesses.Processes)
+            {
+                // There can be multiple processes per app, so only add an app package name if it doesn't already
+                // exist in the list and it is in a suspended state (not running)
+                if (process.PackageFullName != null && !process.IsRunning && !suspendedApps.Contains(process.PackageFullName))
+                {
+                    suspendedApps.Add(process.PackageFullName);
+                }
+            }
+
+            return suspendedApps;
         }
 
         /// <summary>

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
@@ -2,6 +2,9 @@
 // <copyright file="TaskManager.cs" company="Microsoft Corporation">
 //     Licensed under the MIT License. See LICENSE.TXT in the project root license information.
 // </copyright>
+// <copyright file="AppOperation.cs" company="HBO">
+//     Support listing running and suspended apps on Xbox. See LICENSE.TXT in the project root for license information.
+// </copyright>
 //----------------------------------------------------------------------------------------------
 
 using System.Collections.Generic;

--- a/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
+++ b/WindowsDevicePortalWrapper/WindowsDevicePortalWrapper.Shared/Core/TaskManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //----------------------------------------------------------------------------------------------
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Microsoft.Tools.WindowsDevicePortal
@@ -50,6 +51,24 @@ namespace Microsoft.Tools.WindowsDevicePortal
             }
 
             return processId;
+        }
+
+        public async Task<List<string>> GetRunningAppsAsync()
+        {
+            RunningProcesses runningApps = await this.GetRunningProcessesAsync();
+            List<string> runningProcessNames = new List<string>();
+
+            foreach (DeviceProcessInfo process in runningApps.Processes)
+            {
+                // There can be multiple processes per app, so only add an app package name
+                // if it doesn't already exist in the list
+                if (process.PackageFullName != null && !runningProcessNames.Contains(process.PackageFullName))
+                {
+                    runningProcessNames.Add(process.PackageFullName);
+                }
+            }
+
+            return runningProcessNames;
         }
 
         /// <summary>

--- a/XboxWDPDriver.md
+++ b/XboxWDPDriver.md
@@ -42,7 +42,11 @@ Allows getting the list of applications on the console and performing some basic
 Usage:
 ```shell
   /subop:list
-        Lists all installed packages on the console.
+	 Lists all installed packages on the console.
+  /subop:listRunningApps
+	 Lists all running app packages on the cosole.
+  /subop:listSuspendedApps
+	 Lists all suspended app packages on the console.
   /subop:launch /pfn:<packageFullName> /aumid:<appId>
         Starts the requested application.
   /subop:terminate /pfn:<packageFullName>
@@ -54,6 +58,14 @@ Usage:
 Examples:
 ```shell
 XboxWdpDriver.exe /op:app /subop:list
+```
+
+```shell
+XboxWdpDriver.exe /op:app /subop:listRunningApps
+```
+
+```shell
+XboxWdpDriver.exe /op:app /subop:listSuspendedApps
 ```
 
 ```shell


### PR DESCRIPTION
In order to support properly monitoring the app status on Xbox's programatically, we needed to add a bit of additional functionality to the XboxWDP API that wasn't currently being exposed but was available.

## Changes Included:
2 New helper functions in `TaskManager.cs`
* `GetRunningAppsAsync`: Returns a list of package full names of apps currently running on device
* `GetSupsendedAppsAsync`: Returns a list of package full names of apps currently suspended on device

2 New subops to the API in `AppOperation.cs` using the above helpers
* `/op:app /subop:listRunningApps`
* `/op:app /subop:listSupsendedApps`

Readme Updates

## Reviewers
* [ ] @muchoudry 
* [ ] @cluitjenhbo 
* [ ] @brendanjc 
* @HBOCodeLabs/aviato 

![giphy](https://user-images.githubusercontent.com/5848767/37919448-c0add58c-30d8-11e8-82fa-c53af95a1623.gif)